### PR TITLE
Implement squad folders with initial pauta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /data/users/*.json
 /data/squads.json
+/data/squads/*
+!/data/squads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Sistema simples em PHP demonstrando cadastro e login.
 
-Agora é possível criar squads/comitês através do menu lateral.
+Agora é possível criar squads/comitês através do menu lateral. Cada squad recebe
+uma pasta dentro de `data/squads/` onde ficam suas pautas em arquivos JSON.
 
 ## Como executar
 
@@ -14,5 +15,7 @@ Agora é possível criar squads/comitês através do menu lateral.
 3. Acesse `http://localhost:8000` no navegador.
 
 As squads são salvas em `data/squads.json`.
+Cada pasta de squad contém as pautas em `data/squads/<slug>/`. Quando uma squad é
+criada, uma pauta inicial chamada "Pauta Principal" é gerada automaticamente.
 
 Todos os usuários são armazenados em arquivos JSON em `data/users/`. A pasta já existe no repositório, mas os arquivos de dados são ignorados pelo git.

--- a/controllers/SquadController.php
+++ b/controllers/SquadController.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../models/Squad.php';
+require_once __DIR__ . '/../models/Pauta.php';
 
 class SquadController {
     public function addSquad(string $name): void {
@@ -8,6 +9,22 @@ class SquadController {
 
     public function getSquads(): array {
         return Squad::getAll();
+    }
+
+    public function getPautas(string $slug): array {
+        return Pauta::list($slug);
+    }
+
+    public function getPauta(string $slug, string $file): ?array {
+        return Pauta::load($slug, $file);
+    }
+
+    public function savePauta(string $slug, string $file, string $content, ?array $upload): void {
+        Pauta::save($slug, $file, $content, $upload);
+    }
+
+    public function addPauta(string $slug, string $name): void {
+        Pauta::create($slug, $name, '');
     }
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -11,6 +11,15 @@ $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['action']) && $_POST['action'] === 'add_squad' && isset($_SESSION['user'])) {
         $squadController->addSquad($_POST['squad_name'] ?? '');
+    } elseif (isset($_POST['action']) && $_POST['action'] === 'add_pauta' && isset($_SESSION['user'])) {
+        $squadController->addPauta($_GET['squad'] ?? '', $_POST['pauta_name'] ?? '');
+    } elseif (isset($_POST['action']) && $_POST['action'] === 'save_pauta' && isset($_SESSION['user'])) {
+        $squadController->savePauta(
+            $_GET['squad'] ?? '',
+            $_GET['pauta'] ?? '',
+            $_POST['content'] ?? '',
+            $_FILES['image'] ?? null
+        );
     } else {
         $username = trim($_POST['username'] ?? '');
         $password = trim($_POST['password'] ?? '');
@@ -34,7 +43,16 @@ if (isset($_GET['logout'])) {
 
 if (isset($_SESSION['user'])) {
     $squads = $squadController->getSquads();
-    include __DIR__ . '/views/menu.php';
+    if (isset($_GET['pauta']) && isset($_GET['squad'])) {
+        $pauta = $squadController->getPauta($_GET['squad'], $_GET['pauta']);
+        include __DIR__ . '/views/pauta.php';
+    } elseif (isset($_GET['squad'])) {
+        $currentSquad = Squad::getBySlug($_GET['squad']);
+        $pautas = $squadController->getPautas($_GET['squad']);
+        include __DIR__ . '/views/squad.php';
+    } else {
+        include __DIR__ . '/views/menu.php';
+    }
 } else {
     include __DIR__ . '/views/login.php';
 }

--- a/models/Pauta.php
+++ b/models/Pauta.php
@@ -1,0 +1,80 @@
+<?php
+class Pauta {
+    private const BASE_DIR = __DIR__ . '/../data/squads';
+
+    private static function slugify(string $name): string {
+        $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $name));
+        return trim($slug, '-');
+    }
+
+    public static function create(string $squadSlug, string $name, string $content): string {
+        $date = date('Y-m-d');
+        $slug = self::slugify($name);
+        $file = "$date-$slug.json";
+        $dir = self::BASE_DIR . "/$squadSlug";
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $data = [
+            'name' => $name,
+            'content' => $content,
+            'created_at' => $date,
+            'updated_at' => $date
+        ];
+        file_put_contents("$dir/$file", json_encode($data, JSON_PRETTY_PRINT));
+        return $file;
+    }
+
+    public static function list(string $squadSlug): array {
+        $dir = self::BASE_DIR . "/$squadSlug";
+        if (!is_dir($dir)) {
+            return [];
+        }
+        $files = glob("$dir/*.json");
+        $pautas = [];
+        foreach ($files as $path) {
+            $data = json_decode(file_get_contents($path), true);
+            if (!$data) {
+                continue;
+            }
+            $data['file'] = basename($path);
+            $pautas[] = $data;
+        }
+        return $pautas;
+    }
+
+    public static function load(string $squadSlug, string $file): ?array {
+        $path = self::BASE_DIR . "/$squadSlug/$file";
+        if (!file_exists($path)) {
+            return null;
+        }
+        $data = json_decode(file_get_contents($path), true);
+        return $data ?: null;
+    }
+
+    public static function save(string $squadSlug, string $file, string $content, ?array $upload = null): void {
+        $path = self::BASE_DIR . "/$squadSlug/$file";
+        if (!file_exists($path)) {
+            return;
+        }
+        $data = json_decode(file_get_contents($path), true);
+        if (!$data) {
+            $data = [];
+        }
+        if ($upload && isset($upload['tmp_name']) && $upload['tmp_name'] !== '') {
+            $imagesDir = self::BASE_DIR . "/$squadSlug/images";
+            if (!is_dir($imagesDir)) {
+                mkdir($imagesDir, 0777, true);
+            }
+            $target = $imagesDir . '/' . basename($upload['name']);
+            if (move_uploaded_file($upload['tmp_name'], $target)) {
+                $content .= "\n![" . basename($upload['name']) . "](images/" . basename($upload['name']) . ")";
+            }
+        }
+        $data['content'] = $content;
+        $data['updated_at'] = date('Y-m-d');
+        file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
+    }
+}
+?>
+

--- a/models/Squad.php
+++ b/models/Squad.php
@@ -1,6 +1,21 @@
 <?php
 class Squad {
     private const DATA_FILE = __DIR__ . '/../data/squads.json';
+    private const SQUAD_DIR  = __DIR__ . '/../data/squads';
+
+    private static function slugify(string $name): string {
+        $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $name));
+        return trim($slug, '-');
+    }
+
+    public static function getBySlug(string $slug): ?array {
+        foreach (self::getAll() as $squad) {
+            if ($squad['slug'] === $slug) {
+                return $squad;
+            }
+        }
+        return null;
+    }
 
     public static function getAll(): array {
         if (!file_exists(self::DATA_FILE)) {
@@ -15,8 +30,24 @@ class Squad {
         if ($name === '') {
             return;
         }
+
         $squads = self::getAll();
-        $squads[] = $name;
+        $baseSlug = self::slugify($name);
+        $slug = $baseSlug;
+        $i = 1;
+        while (is_dir(self::SQUAD_DIR . '/' . $slug)) {
+            $slug = $baseSlug . '-' . $i++;
+        }
+
+        if (!is_dir(self::SQUAD_DIR)) {
+            mkdir(self::SQUAD_DIR, 0777, true);
+        }
+        mkdir(self::SQUAD_DIR . '/' . $slug, 0777, true);
+
+        Pauta::create($slug, 'Pauta Principal', '');
+
+        $squads[] = ['name' => $name, 'slug' => $slug];
+
         if (!is_dir(dirname(self::DATA_FILE))) {
             mkdir(dirname(self::DATA_FILE), 0777, true);
         }

--- a/views/menu.php
+++ b/views/menu.php
@@ -18,7 +18,9 @@
             <?php if (!empty($squads)): ?>
             <div class="submenu">
                 <?php foreach ($squads as $squad): ?>
-                    <a href="#"><?= htmlspecialchars($squad) ?></a>
+                    <a href="?squad=<?= urlencode($squad['slug']) ?>">
+                        <?= htmlspecialchars($squad['name']) ?>
+                    </a>
                 <?php endforeach; ?>
             </div>
             <?php endif; ?>

--- a/views/pauta.php
+++ b/views/pauta.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>SafeHm - Pauta</title>
+    <link rel="stylesheet" href="public/style.css">
+</head>
+<body>
+<div class="menu">
+    <div class="menu-left">
+        <h2>Menu</h2>
+        <a href="index.php">Início</a>
+        <a href="?squad=<?= urlencode($_GET['squad']) ?>">Voltar à Squad</a>
+        <a href="?logout=1">Sair</a>
+    </div>
+    <div class="content">
+        <h1><?= htmlspecialchars($pauta['name']) ?></h1>
+        <form method="post" enctype="multipart/form-data">
+            <input type="hidden" name="action" value="save_pauta">
+            <textarea name="content" rows="10" style="width:100%;"><?= htmlspecialchars($pauta['content'] ?? '') ?></textarea>
+            <input type="file" name="image" accept="image/*">
+            <button type="submit">Salvar</button>
+        </form>
+    </div>
+</div>
+</body>
+</html>
+

--- a/views/squad.php
+++ b/views/squad.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>SafeHm - Squad</title>
+    <link rel="stylesheet" href="public/style.css">
+</head>
+<body>
+<div class="menu">
+    <div class="menu-left">
+        <h2>Menu</h2>
+        <a href="index.php">Início</a>
+        <div class="squad-menu">
+            <span>Squads/Comitês</span>
+            <?php if (!empty($squads)): ?>
+            <div class="submenu">
+                <?php foreach ($squads as $s): ?>
+                    <a href="?squad=<?= urlencode($s['slug']) ?>">
+                        <?= htmlspecialchars($s['name']) ?>
+                    </a>
+                <?php endforeach; ?>
+            </div>
+            <?php endif; ?>
+        </div>
+        <a href="?logout=1">Sair</a>
+    </div>
+    <div class="content">
+        <h1><?= htmlspecialchars($currentSquad['name']) ?></h1>
+        <form method="post">
+            <input type="hidden" name="action" value="add_pauta">
+            <input type="text" name="pauta_name" placeholder="Nova pauta" required>
+            <button type="submit">Criar Pauta</button>
+        </form>
+        <h2>Pautas</h2>
+        <ul>
+            <?php foreach ($pautas as $p): ?>
+                <li>
+                    <a href="?squad=<?= urlencode($currentSquad['slug']) ?>&pauta=<?= urlencode($p['file']) ?>">
+                        <?= htmlspecialchars($p['name']) ?>
+                    </a>
+                    - Criado em <?= htmlspecialchars($p['created_at']) ?> - Atualizado em <?= htmlspecialchars($p['updated_at']) ?>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+</div>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- organize squads in `data/squads/`
- create initial "Pauta Principal" file for each new squad
- allow listing squads and their pautas
- add basic text editor for pauta with image upload
- document new behaviour and ignore generated data

## Testing
- `php` commands not available in environment

------
https://chatgpt.com/codex/tasks/task_e_6863d0d196ec832b95812ea333720d8e