### PR TITLE
Add emoji customization and editor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Sistema simples em PHP demonstrando cadastro e login.
 
-Agora é possível criar squads/comitês através do menu lateral. Cada squad recebe
-uma pasta dentro de `data/squads/` onde ficam suas pautas em arquivos JSON.
+Agora é possível criar squads/comitês através do menu lateral, escolhendo um emoji para representá-los.
+Cada squad recebe uma pasta dentro de `data/squads/` onde ficam suas pautas em arquivos JSON.
 
 ## Como executar
 
@@ -17,5 +17,6 @@ uma pasta dentro de `data/squads/` onde ficam suas pautas em arquivos JSON.
 As squads são salvas em `data/squads.json`.
 Cada pasta de squad contém as pautas em `data/squads/<slug>/`. Quando uma squad é
 criada, uma pauta inicial chamada "Pauta Principal" é gerada automaticamente.
+As pautas são editadas com um editor Markdown que exibe números de linha, e é possível apenas salvar ou salvar e voltar para a página da squad.
 
 Todos os usuários são armazenados em arquivos JSON em `data/users/`. A pasta já existe no repositório, mas os arquivos de dados são ignorados pelo git.

--- a/controllers/SquadController.php
+++ b/controllers/SquadController.php
@@ -3,8 +3,8 @@ require_once __DIR__ . '/../models/Squad.php';
 require_once __DIR__ . '/../models/Pauta.php';
 
 class SquadController {
-    public function addSquad(string $name): void {
-        Squad::add($name);
+    public function addSquad(string $name, string $emoji): void {
+        Squad::add($name, $emoji);
     }
 
     public function getSquads(): array {

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['action']) && $_POST['action'] === 'add_squad' && isset($_SESSION['user'])) {
-        $squadController->addSquad($_POST['squad_name'] ?? '');
+        $squadController->addSquad($_POST['squad_name'] ?? '', $_POST['squad_emoji'] ?? '');
     } elseif (isset($_POST['action']) && $_POST['action'] === 'add_pauta' && isset($_SESSION['user'])) {
         $squadController->addPauta($_GET['squad'] ?? '', $_POST['pauta_name'] ?? '');
     } elseif (isset($_POST['action']) && $_POST['action'] === 'save_pauta' && isset($_SESSION['user'])) {
@@ -20,6 +20,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_POST['content'] ?? '',
             $_FILES['image'] ?? null
         );
+        if (!empty($_POST['return']) && $_POST['return'] === '1') {
+            header('Location: ?squad=' . urlencode($_GET['squad'] ?? ''));
+            exit;
+        }
     } else {
         $username = trim($_POST['username'] ?? '');
         $password = trim($_POST['password'] ?? '');
@@ -45,6 +49,7 @@ if (isset($_SESSION['user'])) {
     $squads = $squadController->getSquads();
     if (isset($_GET['pauta']) && isset($_GET['squad'])) {
         $pauta = $squadController->getPauta($_GET['squad'], $_GET['pauta']);
+        $currentSquad = Squad::getBySlug($_GET['squad']);
         include __DIR__ . '/views/pauta.php';
     } elseif (isset($_GET['squad'])) {
         $currentSquad = Squad::getBySlug($_GET['squad']);

--- a/models/Squad.php
+++ b/models/Squad.php
@@ -25,8 +25,9 @@ class Squad {
         return is_array($data) ? $data : [];
     }
 
-    public static function add(string $name): void {
+    public static function add(string $name, string $emoji): void {
         $name = trim($name);
+        $emoji = trim($emoji);
         if ($name === '') {
             return;
         }
@@ -46,7 +47,7 @@ class Squad {
 
         Pauta::create($slug, 'Pauta Principal', '');
 
-        $squads[] = ['name' => $name, 'slug' => $slug];
+        $squads[] = ['name' => $name, 'slug' => $slug, 'emoji' => $emoji];
 
         if (!is_dir(dirname(self::DATA_FILE))) {
             mkdir(dirname(self::DATA_FILE), 0777, true);

--- a/public/style.css
+++ b/public/style.css
@@ -57,3 +57,19 @@ input, button {
     padding-left: 20px;
     font-size: 0.9em;
 }
+
+.navbar {
+    background-color: #1e1e1e;
+    padding: 10px;
+    margin-bottom: 20px;
+    border-radius: 4px;
+}
+
+.navbar a {
+    color: #fff;
+    text-decoration: none;
+}
+
+.navbar a:hover {
+    text-decoration: underline;
+}

--- a/views/menu.php
+++ b/views/menu.php
@@ -7,43 +7,12 @@
 </head>
 <body>
 <div class="menu">
-    <div class="menu-left">
-        <h2>Menu</h2>
-        <a href="#">Início</a>
-        <a href="#">Perfil</a>
-        <a href="#">Configurações</a>
-        <div class="squad-menu">
-            <span>Squads/Comitês</span>
-            <button id="add-squad-btn" type="button">+</button>
-            <?php if (!empty($squads)): ?>
-            <div class="submenu">
-                <?php foreach ($squads as $squad): ?>
-                    <a href="?squad=<?= urlencode($squad['slug']) ?>">
-                        <?= htmlspecialchars($squad['name']) ?>
-                    </a>
-                <?php endforeach; ?>
-            </div>
-            <?php endif; ?>
-            <form id="add-squad-form" method="post" style="display:none;">
-                <input type="hidden" name="action" value="add_squad">
-                <input type="hidden" name="squad_name" id="squad-name-input">
-            </form>
-        </div>
-        <a href="?logout=1">Sair</a>
-    </div>
+    <?php include __DIR__ . '/partials/sidebar.php'; ?>
     <div class="content">
+        <div class="navbar">Home</div>
         <h1>Bem-vindo, <?= htmlspecialchars($_SESSION['user']) ?>!</h1>
         <p>Conteúdo do SafeHm aqui...</p>
     </div>
 </div>
-<script>
-document.getElementById('add-squad-btn').addEventListener('click', function() {
-    const name = prompt('Nome da Squad/Comitê:');
-    if (name) {
-        document.getElementById('squad-name-input').value = name;
-        document.getElementById('add-squad-form').submit();
-    }
-});
-</script>
 </body>
 </html>

--- a/views/partials/sidebar.php
+++ b/views/partials/sidebar.php
@@ -1,0 +1,41 @@
+<div class="menu-left">
+    <h2>Menu</h2>
+    <a href="index.php">🏠 Início</a>
+    <a href="#">👤 Perfil</a>
+    <a href="#">⚙️ Configurações</a>
+    <div class="squad-menu">
+        <span>Squads/Comitês</span>
+        <button id="add-squad-btn" type="button">+</button>
+        <?php if (!empty($squads)): ?>
+        <div class="submenu">
+            <?php foreach ($squads as $squad): ?>
+                <a href="?squad=<?= urlencode($squad['slug']) ?>">
+                    <?= htmlspecialchars($squad['emoji'] ?? '') ?> <?= htmlspecialchars($squad['name']) ?>
+                </a>
+            <?php endforeach; ?>
+        </div>
+        <?php endif; ?>
+        <form id="add-squad-form" method="post" style="display:none;">
+            <input type="hidden" name="action" value="add_squad">
+            <input type="hidden" name="squad_name" id="squad-name-input">
+            <input type="hidden" name="squad_emoji" id="squad-emoji-input">
+        </form>
+    </div>
+    <a href="?logout=1">🚪 Sair</a>
+</div>
+<script>
+var btn = document.getElementById('add-squad-btn');
+if(btn){
+    btn.addEventListener('click', function() {
+        const name = prompt('Nome da Squad/Comitê:');
+        if (name) {
+            const emoji = prompt('Emoji da Squad/Comitê (ex: 😃):', '');
+            if (emoji) {
+                document.getElementById('squad-name-input').value = name;
+                document.getElementById('squad-emoji-input').value = emoji;
+                document.getElementById('add-squad-form').submit();
+            }
+        }
+    });
+}
+</script>

--- a/views/pauta.php
+++ b/views/pauta.php
@@ -7,20 +7,35 @@
 </head>
 <body>
 <div class="menu">
-    <div class="menu-left">
-        <h2>Menu</h2>
-        <a href="index.php">Início</a>
-        <a href="?squad=<?= urlencode($_GET['squad']) ?>">Voltar à Squad</a>
-        <a href="?logout=1">Sair</a>
-    </div>
+    <?php include __DIR__ . '/partials/sidebar.php'; ?>
     <div class="content">
+        <div class="navbar">
+            <a href="index.php">Home</a> /
+            <a href="?squad=<?= urlencode($currentSquad['slug']) ?>">
+                <?= htmlspecialchars($currentSquad['emoji'] ?? '') ?> <?= htmlspecialchars($currentSquad['name']) ?>
+            </a>
+            / <?= htmlspecialchars($pauta['name']) ?>
+        </div>
         <h1><?= htmlspecialchars($pauta['name']) ?></h1>
         <form method="post" enctype="multipart/form-data">
             <input type="hidden" name="action" value="save_pauta">
-            <textarea name="content" rows="10" style="width:100%;"><?= htmlspecialchars($pauta['content'] ?? '') ?></textarea>
+            <textarea id="editor" name="content" rows="10" style="width:100%;"><?= htmlspecialchars($pauta['content'] ?? '') ?></textarea>
             <input type="file" name="image" accept="image/*">
-            <button type="submit">Salvar</button>
+            <button type="submit" name="return" value="0">Salvar</button>
+            <button type="submit" name="return" value="1">Salvar e voltar</button>
         </form>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
+        <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+        <script>
+            new EasyMDE({
+                element: document.getElementById('editor'),
+                autoDownloadFontAwesome: false,
+                renderingConfig: { singleLineBreaks: false },
+                spellChecker: false,
+                toolbar: ["bold", "italic", "heading", "|", "quote", "unordered-list", "ordered-list", "link", "preview"],
+                codemirrorOptions: { lineNumbers: true, theme: 'base16-dark' }
+            });
+        </script>
     </div>
 </div>
 </body>

--- a/views/squad.php
+++ b/views/squad.php
@@ -7,25 +7,10 @@
 </head>
 <body>
 <div class="menu">
-    <div class="menu-left">
-        <h2>Menu</h2>
-        <a href="index.php">Início</a>
-        <div class="squad-menu">
-            <span>Squads/Comitês</span>
-            <?php if (!empty($squads)): ?>
-            <div class="submenu">
-                <?php foreach ($squads as $s): ?>
-                    <a href="?squad=<?= urlencode($s['slug']) ?>">
-                        <?= htmlspecialchars($s['name']) ?>
-                    </a>
-                <?php endforeach; ?>
-            </div>
-            <?php endif; ?>
-        </div>
-        <a href="?logout=1">Sair</a>
-    </div>
+    <?php include __DIR__ . '/partials/sidebar.php'; ?>
     <div class="content">
-        <h1><?= htmlspecialchars($currentSquad['name']) ?></h1>
+        <div class="navbar"><a href="index.php">Home</a> / <?= htmlspecialchars($currentSquad['emoji'] ?? '') ?> <?= htmlspecialchars($currentSquad['name']) ?></div>
+        <h1><?= htmlspecialchars($currentSquad['emoji'] ?? '') ?> <?= htmlspecialchars($currentSquad['name']) ?></h1>
         <form method="post">
             <input type="hidden" name="action" value="add_pauta">
             <input type="text" name="pauta_name" placeholder="Nova pauta" required>


### PR DESCRIPTION
## Summary
- allow choosing an emoji when creating a squad
- add consistent sidebar partial with emojis and icons
- show breadcrumb navbar on pages
- add Save and Save & Return buttons for pautas
- integrate EasyMDE editor with line numbers

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d38a1470832b8518a2ce8bb23f9e