### PR TITLE
Integrar Quill editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ Cada squad recebe uma pasta dentro de `data/squads/` onde ficam suas pautas em a
 As squads são salvas em `data/squads.json`.
 Cada pasta de squad contém as pautas em `data/squads/<slug>/`. Quando uma squad é
 criada, uma pauta inicial chamada "Pauta Principal" é gerada automaticamente.
-As pautas são editadas com um editor Markdown que exibe números de linha, e é possível apenas salvar ou salvar e voltar para a página da squad.
+As pautas são editadas com o [Quill](https://quilljs.com/), um editor rich text em modo escuro. É possível apenas salvar ou salvar e voltar para a página da squad.
 
 Todos os usuários são armazenados em arquivos JSON em `data/users/`. A pasta já existe no repositório, mas os arquivos de dados são ignorados pelo git.

--- a/public/style.css
+++ b/public/style.css
@@ -73,3 +73,22 @@ input, button {
 .navbar a:hover {
     text-decoration: underline;
 }
+
+/* Quill custom dark theme */
+.ql-toolbar.ql-snow,
+.ql-container.ql-snow {
+    border: 1px solid #333;
+}
+
+.ql-toolbar.ql-snow {
+    background-color: #1e1e1e;
+}
+
+.ql-container.ql-snow {
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+}
+
+.ql-editor {
+    min-height: 200px;
+}

--- a/views/pauta.php
+++ b/views/pauta.php
@@ -17,23 +17,20 @@
             / <?= htmlspecialchars($pauta['name']) ?>
         </div>
         <h1><?= htmlspecialchars($pauta['name']) ?></h1>
-        <form method="post" enctype="multipart/form-data">
+        <form method="post" enctype="multipart/form-data" id="pauta-form">
             <input type="hidden" name="action" value="save_pauta">
-            <textarea id="editor" name="content" rows="10" style="width:100%;"><?= htmlspecialchars($pauta['content'] ?? '') ?></textarea>
+            <input type="hidden" name="content" id="content-input">
+            <div id="editor" style="height:300px;"><?= $pauta['content'] ?? '' ?></div>
             <input type="file" name="image" accept="image/*">
             <button type="submit" name="return" value="0">Salvar</button>
             <button type="submit" name="return" value="1">Salvar e voltar</button>
         </form>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.css">
-        <script src="https://cdn.jsdelivr.net/npm/easymde/dist/easymde.min.js"></script>
+        <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+        <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
         <script>
-            new EasyMDE({
-                element: document.getElementById('editor'),
-                autoDownloadFontAwesome: false,
-                renderingConfig: { singleLineBreaks: false },
-                spellChecker: false,
-                toolbar: ["bold", "italic", "heading", "|", "quote", "unordered-list", "ordered-list", "link", "preview"],
-                codemirrorOptions: { lineNumbers: true, theme: 'base16-dark' }
+            var quill = new Quill('#editor', { theme: 'snow' });
+            document.getElementById('pauta-form').addEventListener('submit', function () {
+                document.getElementById('content-input').value = quill.root.innerHTML;
             });
         </script>
     </div>


### PR DESCRIPTION
## Summary
- switch from EasyMDE to Quill on the pauta page
- style Quill components for dark mode
- document new editor in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d55f6488832ba179803281bd384f