### PR TITLE
Update interface and remove emoji usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Sistema simples em PHP demonstrando cadastro e login.
 
-Agora é possível criar squads/comitês através do menu lateral, escolhendo um emoji para representá-los.
-Cada squad recebe uma pasta dentro de `data/squads/` onde ficam suas pautas em arquivos JSON.
+É possível criar squads/comitês através do menu lateral. Cada squad recebe uma pasta dentro de `data/squads/` onde ficam suas pautas em arquivos JSON.
 
 ## Como executar
 

--- a/controllers/SquadController.php
+++ b/controllers/SquadController.php
@@ -3,8 +3,8 @@ require_once __DIR__ . '/../models/Squad.php';
 require_once __DIR__ . '/../models/Pauta.php';
 
 class SquadController {
-    public function addSquad(string $name, string $emoji): void {
-        Squad::add($name, $emoji);
+    public function addSquad(string $name): void {
+        Squad::add($name);
     }
 
     public function getSquads(): array {

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['action']) && $_POST['action'] === 'add_squad' && isset($_SESSION['user'])) {
-        $squadController->addSquad($_POST['squad_name'] ?? '', $_POST['squad_emoji'] ?? '');
+        $squadController->addSquad($_POST['squad_name'] ?? '');
     } elseif (isset($_POST['action']) && $_POST['action'] === 'add_pauta' && isset($_SESSION['user'])) {
         $squadController->addPauta($_GET['squad'] ?? '', $_POST['pauta_name'] ?? '');
     } elseif (isset($_POST['action']) && $_POST['action'] === 'save_pauta' && isset($_SESSION['user'])) {

--- a/models/Squad.php
+++ b/models/Squad.php
@@ -25,9 +25,8 @@ class Squad {
         return is_array($data) ? $data : [];
     }
 
-    public static function add(string $name, string $emoji): void {
+    public static function add(string $name): void {
         $name = trim($name);
-        $emoji = trim($emoji);
         if ($name === '') {
             return;
         }
@@ -47,7 +46,7 @@ class Squad {
 
         Pauta::create($slug, 'Pauta Principal', '');
 
-        $squads[] = ['name' => $name, 'slug' => $slug, 'emoji' => $emoji];
+        $squads[] = ['name' => $name, 'slug' => $slug];
 
         if (!is_dir(dirname(self::DATA_FILE))) {
             mkdir(dirname(self::DATA_FILE), 0777, true);

--- a/public/style.css
+++ b/public/style.css
@@ -20,6 +20,9 @@ input, button {
     border: none;
     border-radius: 4px;
 }
+a, a:visited {
+    color: #8ab4f8;
+}
 .menu {
     display: flex;
 }
@@ -31,7 +34,6 @@ input, button {
 }
 .menu-left a {
     display: block;
-    color: #fff;
     padding: 10px 0;
     text-decoration: none;
 }
@@ -66,7 +68,6 @@ input, button {
 }
 
 .navbar a {
-    color: #fff;
     text-decoration: none;
 }
 
@@ -91,4 +92,34 @@ input, button {
 
 .ql-editor {
     min-height: 200px;
+}
+
+.pauta-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 15px;
+}
+
+.pauta-table th,
+.pauta-table td {
+    border: 1px solid #333;
+    padding: 8px;
+}
+
+.add-pauta-form {
+    display: flex;
+    gap: 10px;
+}
+
+.add-pauta-form input {
+    flex: 1;
+}
+
+.button-row {
+    display: flex;
+    gap: 10px;
+}
+
+.button-row button {
+    width: 100%;
 }

--- a/views/partials/sidebar.php
+++ b/views/partials/sidebar.php
@@ -1,8 +1,6 @@
 <div class="menu-left">
     <h2>Menu</h2>
-    <a href="index.php">🏠 Início</a>
-    <a href="#">👤 Perfil</a>
-    <a href="#">⚙️ Configurações</a>
+    <a href="index.php">Início</a>
     <div class="squad-menu">
         <span>Squads/Comitês</span>
         <button id="add-squad-btn" type="button">+</button>
@@ -10,7 +8,7 @@
         <div class="submenu">
             <?php foreach ($squads as $squad): ?>
                 <a href="?squad=<?= urlencode($squad['slug']) ?>">
-                    <?= htmlspecialchars($squad['emoji'] ?? '') ?> <?= htmlspecialchars($squad['name']) ?>
+                    <?= htmlspecialchars($squad['name']) ?>
                 </a>
             <?php endforeach; ?>
         </div>
@@ -18,10 +16,9 @@
         <form id="add-squad-form" method="post" style="display:none;">
             <input type="hidden" name="action" value="add_squad">
             <input type="hidden" name="squad_name" id="squad-name-input">
-            <input type="hidden" name="squad_emoji" id="squad-emoji-input">
         </form>
     </div>
-    <a href="?logout=1">🚪 Sair</a>
+    <a href="?logout=1">Sair</a>
 </div>
 <script>
 var btn = document.getElementById('add-squad-btn');
@@ -29,12 +26,8 @@ if(btn){
     btn.addEventListener('click', function() {
         const name = prompt('Nome da Squad/Comitê:');
         if (name) {
-            const emoji = prompt('Emoji da Squad/Comitê (ex: 😃):', '');
-            if (emoji) {
-                document.getElementById('squad-name-input').value = name;
-                document.getElementById('squad-emoji-input').value = emoji;
-                document.getElementById('add-squad-form').submit();
-            }
+            document.getElementById('squad-name-input').value = name;
+            document.getElementById('add-squad-form').submit();
         }
     });
 }

--- a/views/pauta.php
+++ b/views/pauta.php
@@ -12,7 +12,7 @@
         <div class="navbar">
             <a href="index.php">Home</a> /
             <a href="?squad=<?= urlencode($currentSquad['slug']) ?>">
-                <?= htmlspecialchars($currentSquad['emoji'] ?? '') ?> <?= htmlspecialchars($currentSquad['name']) ?>
+                <?= htmlspecialchars($currentSquad['name']) ?>
             </a>
             / <?= htmlspecialchars($pauta['name']) ?>
         </div>
@@ -22,8 +22,10 @@
             <input type="hidden" name="content" id="content-input">
             <div id="editor" style="height:300px;"><?= $pauta['content'] ?? '' ?></div>
             <input type="file" name="image" accept="image/*">
-            <button type="submit" name="return" value="0">Salvar</button>
-            <button type="submit" name="return" value="1">Salvar e voltar</button>
+            <div class="button-row">
+                <button type="submit" name="return" value="0">Salvar</button>
+                <button type="submit" name="return" value="1">Salvar e voltar</button>
+            </div>
         </form>
         <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
         <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>

--- a/views/squad.php
+++ b/views/squad.php
@@ -9,24 +9,28 @@
 <div class="menu">
     <?php include __DIR__ . '/partials/sidebar.php'; ?>
     <div class="content">
-        <div class="navbar"><a href="index.php">Home</a> / <?= htmlspecialchars($currentSquad['emoji'] ?? '') ?> <?= htmlspecialchars($currentSquad['name']) ?></div>
-        <h1><?= htmlspecialchars($currentSquad['emoji'] ?? '') ?> <?= htmlspecialchars($currentSquad['name']) ?></h1>
-        <form method="post">
+        <div class="navbar"><a href="index.php">Home</a> / <?= htmlspecialchars($currentSquad['name']) ?></div>
+        <h1><?= htmlspecialchars($currentSquad['name']) ?></h1>
+        <h2>Pautas</h2>
+        <table class="pauta-table">
+            <thead>
+                <tr><th>Nome</th><th>Criado em</th><th>Atualizado em</th></tr>
+            </thead>
+            <tbody>
+            <?php foreach ($pautas as $p): ?>
+                <tr>
+                    <td><a href="?squad=<?= urlencode($currentSquad['slug']) ?>&pauta=<?= urlencode($p['file']) ?>"><?= htmlspecialchars($p['name']) ?></a></td>
+                    <td><?= htmlspecialchars($p['created_at']) ?></td>
+                    <td><?= htmlspecialchars($p['updated_at']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+        <form method="post" class="add-pauta-form">
             <input type="hidden" name="action" value="add_pauta">
             <input type="text" name="pauta_name" placeholder="Nova pauta" required>
             <button type="submit">Criar Pauta</button>
         </form>
-        <h2>Pautas</h2>
-        <ul>
-            <?php foreach ($pautas as $p): ?>
-                <li>
-                    <a href="?squad=<?= urlencode($currentSquad['slug']) ?>&pauta=<?= urlencode($p['file']) ?>">
-                        <?= htmlspecialchars($p['name']) ?>
-                    </a>
-                    - Criado em <?= htmlspecialchars($p['created_at']) ?> - Atualizado em <?= htmlspecialchars($p['updated_at']) ?>
-                </li>
-            <?php endforeach; ?>
-        </ul>
     </div>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- drop emoji features from squads and navigation
- display squad pautas in a table and move the add form below
- tidy up buttons and global link style
- clean up sidebar menu items

## Testing
- `php -l index.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6863d82fbf28832bab85284a3972c5e2