### PR TITLE
Implement comment system with status configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ criada, uma pauta inicial chamada "Pauta Principal" é gerada automaticamente.
 As pautas são editadas com o [Quill](https://quilljs.com/), um editor rich text em modo escuro. É possível apenas salvar ou salvar e voltar para a página da squad.
 
 Todos os usuários são armazenados em arquivos JSON em `data/users/`. A pasta já existe no repositório, mas os arquivos de dados são ignorados pelo git.
+
+O sistema também permite adicionar comentários em cada pauta. Os comentários possuem um status que pode ser configurado em "Configurações > Status de comentários". Por padrão já existem três status: Aberto, Em Andamento e Resolvido.

--- a/controllers/CommentStatusController.php
+++ b/controllers/CommentStatusController.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../models/CommentStatus.php';
+
+class CommentStatusController {
+    public function getStatuses(): array {
+        return CommentStatus::getAll();
+    }
+
+    public function addStatus(string $status): void {
+        CommentStatus::add($status);
+    }
+
+    public function removeStatus(string $status): void {
+        CommentStatus::remove($status);
+    }
+}
+?>

--- a/controllers/SquadController.php
+++ b/controllers/SquadController.php
@@ -26,5 +26,13 @@ class SquadController {
     public function addPauta(string $slug, string $name): void {
         Pauta::create($slug, $name, '');
     }
+
+    public function addComment(string $slug, string $file, string $user, string $text, string $status): void {
+        Pauta::addComment($slug, $file, $user, $text, $status);
+    }
+
+    public function updateCommentStatus(string $slug, string $file, int $index, string $status): void {
+        Pauta::updateCommentStatus($slug, $file, $index, $status);
+    }
 }
 ?>

--- a/models/CommentStatus.php
+++ b/models/CommentStatus.php
@@ -1,0 +1,40 @@
+<?php
+class CommentStatus {
+    private const FILE = __DIR__ . '/../data/comment_statuses.json';
+
+    public static function ensure(): void {
+        if (!file_exists(self::FILE)) {
+            $default = ['Aberto', 'Em Andamento', 'Resolvido'];
+            if (!is_dir(dirname(self::FILE))) {
+                mkdir(dirname(self::FILE), 0777, true);
+            }
+            file_put_contents(self::FILE, json_encode($default, JSON_PRETTY_PRINT));
+        }
+    }
+
+    public static function getAll(): array {
+        self::ensure();
+        $data = json_decode(file_get_contents(self::FILE), true);
+        return is_array($data) ? $data : [];
+    }
+
+    public static function add(string $status): void {
+        $status = trim($status);
+        if ($status === '') {
+            return;
+        }
+        $statuses = self::getAll();
+        if (in_array($status, $statuses)) {
+            return;
+        }
+        $statuses[] = $status;
+        file_put_contents(self::FILE, json_encode($statuses, JSON_PRETTY_PRINT));
+    }
+
+    public static function remove(string $status): void {
+        $statuses = self::getAll();
+        $statuses = array_values(array_filter($statuses, fn($s) => $s !== $status));
+        file_put_contents(self::FILE, json_encode($statuses, JSON_PRETTY_PRINT));
+    }
+}
+?>

--- a/models/Pauta.php
+++ b/models/Pauta.php
@@ -75,6 +75,33 @@ class Pauta {
         $data['updated_at'] = date('Y-m-d');
         file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
     }
+
+    public static function addComment(string $squadSlug, string $file, string $user, string $text, string $status): void {
+        $path = self::BASE_DIR . "/$squadSlug/$file";
+        if (!file_exists($path)) {
+            return;
+        }
+        $data = json_decode(file_get_contents($path), true) ?: [];
+        $data['comments'][] = [
+            'user' => $user,
+            'text' => $text,
+            'status' => $status,
+            'created_at' => date('Y-m-d H:i:s')
+        ];
+        file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    public static function updateCommentStatus(string $squadSlug, string $file, int $index, string $status): void {
+        $path = self::BASE_DIR . "/$squadSlug/$file";
+        if (!file_exists($path)) {
+            return;
+        }
+        $data = json_decode(file_get_contents($path), true) ?: [];
+        if (isset($data['comments'][$index])) {
+            $data['comments'][$index]['status'] = $status;
+            file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
+        }
+    }
 }
 ?>
 

--- a/public/style.css
+++ b/public/style.css
@@ -123,3 +123,10 @@ a, a:visited {
 .button-row button {
     width: 100%;
 }
+
+.comment-list { list-style: none; padding: 0; }
+.comment-list li { margin-bottom: 10px; }
+.add-comment-form textarea { width: 100%; height: 60px; margin-bottom: 5px; }
+.status-list { list-style: none; padding: 0; }
+.status-list li { margin-bottom: 5px; }
+

--- a/views/partials/sidebar.php
+++ b/views/partials/sidebar.php
@@ -18,6 +18,12 @@
             <input type="hidden" name="squad_name" id="squad-name-input">
         </form>
     </div>
+    <div class="config-menu">
+        <span>Configurações</span>
+        <div class="submenu">
+            <a href="?config=statuses">Status de comentários</a>
+        </div>
+    </div>
     <a href="?logout=1">Sair</a>
 </div>
 <script>

--- a/views/pauta.php
+++ b/views/pauta.php
@@ -21,11 +21,38 @@
             <input type="hidden" name="action" value="save_pauta">
             <input type="hidden" name="content" id="content-input">
             <div id="editor" style="height:300px;"><?= $pauta['content'] ?? '' ?></div>
-            <input type="file" name="image" accept="image/*">
             <div class="button-row">
                 <button type="submit" name="return" value="0">Salvar</button>
                 <button type="submit" name="return" value="1">Salvar e voltar</button>
             </div>
+        </form>
+        <h2>Comentários</h2>
+        <ul class="comment-list">
+            <?php foreach (($pauta['comments'] ?? []) as $idx => $c): ?>
+                <li>
+                    <strong><?= htmlspecialchars($c['user']) ?>:</strong>
+                    <?= nl2br(htmlspecialchars($c['text'])) ?>
+                    <form method="post" class="status-form" style="display:inline;">
+                        <input type="hidden" name="action" value="update_comment_status">
+                        <input type="hidden" name="comment_index" value="<?= $idx ?>">
+                        <select name="new_status" onchange="this.form.submit()">
+                            <?php foreach ($statuses as $st): ?>
+                                <option value="<?= htmlspecialchars($st) ?>" <?= $c['status'] === $st ? 'selected' : '' ?>><?= htmlspecialchars($st) ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </form>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+        <form method="post" class="add-comment-form">
+            <input type="hidden" name="action" value="add_comment">
+            <textarea name="comment_text" placeholder="Seu comentário" required></textarea>
+            <select name="comment_status">
+                <?php foreach ($statuses as $st): ?>
+                    <option value="<?= htmlspecialchars($st) ?>"><?= htmlspecialchars($st) ?></option>
+                <?php endforeach; ?>
+            </select>
+            <button type="submit">Comentar</button>
         </form>
         <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
         <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>

--- a/views/statuses.php
+++ b/views/statuses.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>SafeHm - Status de Comentários</title>
+    <link rel="stylesheet" href="public/style.css">
+</head>
+<body>
+<div class="menu">
+    <?php include __DIR__ . '/partials/sidebar.php'; ?>
+    <div class="content">
+        <div class="navbar"><a href="index.php">Home</a> / Configurações / Status de comentários</div>
+        <h1>Status de Comentários</h1>
+        <ul class="status-list">
+            <?php foreach ($statuses as $st): ?>
+                <li>
+                    <?= htmlspecialchars($st) ?>
+                    <form method="post" style="display:inline;">
+                        <input type="hidden" name="action" value="remove_status">
+                        <input type="hidden" name="status" value="<?= htmlspecialchars($st) ?>">
+                        <button type="submit">Remover</button>
+                    </form>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+        <form method="post" class="add-status-form">
+            <input type="hidden" name="action" value="add_status">
+            <input type="text" name="status" placeholder="Novo status" required>
+            <button type="submit">Adicionar</button>
+        </form>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove attachment upload from pauta view
- add comment support to pautas
- allow comment status updates using dropdowns
- add status configuration page in sidebar
- define default comment statuses
- document new feature

## Testing
- `php` commands were not available so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6863dc27390c832b8d5582400a790699