### PR TITLE
Implement colored comment statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ As pautas são editadas com o [Quill](https://quilljs.com/), um editor rich text
 
 Todos os usuários são armazenados em arquivos JSON em `data/users/`. A pasta já existe no repositório, mas os arquivos de dados são ignorados pelo git.
 
-O sistema também permite adicionar comentários em cada pauta. Os comentários possuem um status que pode ser configurado em "Configurações > Status de comentários". Por padrão já existem três status: Aberto, Em Andamento e Resolvido.
+O sistema também permite adicionar comentários em cada pauta. Os comentários possuem um status que pode ser configurado em "Configurações > Status de comentários". Cada status possui uma cor RGB para facilitar a visualização. Por padrão já existem três status: Aberto, Em Andamento e Resolvido. Nos comentários é exibida a data e hora de criação junto do status colorido.

--- a/controllers/CommentStatusController.php
+++ b/controllers/CommentStatusController.php
@@ -6,8 +6,12 @@ class CommentStatusController {
         return CommentStatus::getAll();
     }
 
-    public function addStatus(string $status): void {
-        CommentStatus::add($status);
+    public function addStatus(string $status, string $color): void {
+        CommentStatus::add($status, $color);
+    }
+
+    public function updateStatus(string $status, string $color): void {
+        CommentStatus::updateColor($status, $color);
     }
 
     public function removeStatus(string $status): void {

--- a/index.php
+++ b/index.php
@@ -29,7 +29,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             exit;
         }
     } elseif (isset($_POST['action']) && $_POST['action'] === 'add_status' && isset($_SESSION['user'])) {
-        $statusController->addStatus($_POST['status'] ?? '');
+        $statusController->addStatus($_POST['status'] ?? '', $_POST['color'] ?? '#ffffff');
+        $statuses = $statusController->getStatuses();
+    } elseif (isset($_POST['action']) && $_POST['action'] === 'update_status' && isset($_SESSION['user'])) {
+        $statusController->updateStatus($_POST['status'] ?? '', $_POST['color'] ?? '#ffffff');
         $statuses = $statusController->getStatuses();
     } elseif (isset($_POST['action']) && $_POST['action'] === 'remove_status' && isset($_SESSION['user'])) {
         $statusController->removeStatus($_POST['status'] ?? '');
@@ -74,6 +77,10 @@ if (isset($_GET['logout'])) {
 
 if (isset($_SESSION['user'])) {
     $squads = $squadController->getSquads();
+    $statusMap = [];
+    foreach ($statuses as $s) {
+        $statusMap[$s['name']] = $s['color'];
+    }
     if (isset($_GET['config']) && $_GET['config'] === 'statuses') {
         $statuses = $statusController->getStatuses();
         include __DIR__ . '/views/statuses.php';

--- a/views/pauta.php
+++ b/views/pauta.php
@@ -32,12 +32,16 @@
                 <li>
                     <strong><?= htmlspecialchars($c['user']) ?>:</strong>
                     <?= nl2br(htmlspecialchars($c['text'])) ?>
+                    <em>(<?= htmlspecialchars($c['created_at']) ?>)</em>
+                    <span style="color: <?= htmlspecialchars($statusMap[$c['status']] ?? '#fff') ?>; font-weight:bold;">
+                        <?= htmlspecialchars($c['status']) ?>
+                    </span>
                     <form method="post" class="status-form" style="display:inline;">
                         <input type="hidden" name="action" value="update_comment_status">
                         <input type="hidden" name="comment_index" value="<?= $idx ?>">
                         <select name="new_status" onchange="this.form.submit()">
                             <?php foreach ($statuses as $st): ?>
-                                <option value="<?= htmlspecialchars($st) ?>" <?= $c['status'] === $st ? 'selected' : '' ?>><?= htmlspecialchars($st) ?></option>
+                                <option value="<?= htmlspecialchars($st['name']) ?>" style="color: <?= htmlspecialchars($st['color']) ?>;" <?= $c['status'] === $st['name'] ? 'selected' : '' ?>><?= htmlspecialchars($st['name']) ?></option>
                             <?php endforeach; ?>
                         </select>
                     </form>
@@ -49,7 +53,9 @@
             <textarea name="comment_text" placeholder="Seu comentário" required></textarea>
             <select name="comment_status">
                 <?php foreach ($statuses as $st): ?>
-                    <option value="<?= htmlspecialchars($st) ?>"><?= htmlspecialchars($st) ?></option>
+                    <option value="<?= htmlspecialchars($st['name']) ?>" style="color: <?= htmlspecialchars($st['color']) ?>;">
+                        <?= htmlspecialchars($st['name']) ?>
+                    </option>
                 <?php endforeach; ?>
             </select>
             <button type="submit">Comentar</button>

--- a/views/statuses.php
+++ b/views/statuses.php
@@ -14,11 +14,18 @@
         <ul class="status-list">
             <?php foreach ($statuses as $st): ?>
                 <li>
-                    <?= htmlspecialchars($st) ?>
+                    <span style="color: <?= htmlspecialchars($st['color']) ?>; font-weight:bold;">
+                        <?= htmlspecialchars($st['name']) ?>
+                    </span>
                     <form method="post" style="display:inline;">
                         <input type="hidden" name="action" value="remove_status">
-                        <input type="hidden" name="status" value="<?= htmlspecialchars($st) ?>">
+                        <input type="hidden" name="status" value="<?= htmlspecialchars($st['name']) ?>">
                         <button type="submit">Remover</button>
+                    </form>
+                    <form method="post" style="display:inline; margin-left:5px;">
+                        <input type="hidden" name="action" value="update_status">
+                        <input type="hidden" name="status" value="<?= htmlspecialchars($st['name']) ?>">
+                        <input type="color" name="color" value="<?= htmlspecialchars($st['color']) ?>" onchange="this.form.submit()">
                     </form>
                 </li>
             <?php endforeach; ?>
@@ -26,6 +33,7 @@
         <form method="post" class="add-status-form">
             <input type="hidden" name="action" value="add_status">
             <input type="text" name="status" placeholder="Novo status" required>
+            <input type="color" name="color" value="#ffffff">
             <button type="submit">Adicionar</button>
         </form>
     </div>


### PR DESCRIPTION
## Summary
- allow RGB color when creating and editing comment statuses
- display colored status and timestamp for comments
- update README about colored statuses

## Testing
- `php -l controllers/CommentStatusController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863e0bfe08c832ba77a266d5df0e850