### PR TITLE
Implement pauta deletion and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Sistema simples em PHP demonstrando cadastro e login.
 
 É possível criar squads/comitês através do menu lateral. Cada squad recebe uma pasta dentro de `data/squads/` onde ficam suas pautas em arquivos JSON.
+Agora também é possível remover pautas já criadas através da lista de pautas da squad.
 
 ## Como executar
 

--- a/controllers/SquadController.php
+++ b/controllers/SquadController.php
@@ -34,5 +34,9 @@ class SquadController {
     public function updateCommentStatus(string $slug, string $file, int $index, string $status): void {
         Pauta::updateCommentStatus($slug, $file, $index, $status);
     }
+
+    public function removePauta(string $slug, string $file): void {
+        Pauta::remove($slug, $file);
+    }
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -17,6 +17,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $squadController->addSquad($_POST['squad_name'] ?? '');
     } elseif (isset($_POST['action']) && $_POST['action'] === 'add_pauta' && isset($_SESSION['user'])) {
         $squadController->addPauta($_GET['squad'] ?? '', $_POST['pauta_name'] ?? '');
+    } elseif (isset($_POST['action']) && $_POST['action'] === 'remove_pauta' && isset($_SESSION['user'])) {
+        $squadController->removePauta($_GET['squad'] ?? '', $_POST['pauta_file'] ?? '');
+        $pautas = $squadController->getPautas($_GET['squad'] ?? '');
     } elseif (isset($_POST['action']) && $_POST['action'] === 'save_pauta' && isset($_SESSION['user'])) {
         $squadController->savePauta(
             $_GET['squad'] ?? '',

--- a/models/Pauta.php
+++ b/models/Pauta.php
@@ -102,6 +102,13 @@ class Pauta {
             file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
         }
     }
+
+    public static function remove(string $squadSlug, string $file): void {
+        $path = self::BASE_DIR . "/$squadSlug/$file";
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
 }
 ?>
 

--- a/public/style.css
+++ b/public/style.css
@@ -106,6 +106,19 @@ a, a:visited {
     padding: 8px;
 }
 
+.pauta-table th {
+    background-color: #1e1e1e;
+    color: #8ab4f8;
+}
+
+.pauta-table tr:nth-child(even) {
+    background-color: #1a1a1a;
+}
+
+.pauta-table tr:hover {
+    background-color: #2a2a2a;
+}
+
 .add-pauta-form {
     display: flex;
     gap: 10px;
@@ -127,6 +140,26 @@ a, a:visited {
 .comment-list { list-style: none; padding: 0; }
 .comment-list li { margin-bottom: 10px; }
 .add-comment-form textarea { width: 100%; height: 60px; margin-bottom: 5px; }
-.status-list { list-style: none; padding: 0; }
-.status-list li { margin-bottom: 5px; }
+
+.status-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 15px;
+}
+
+.status-table th,
+.status-table td {
+    border: 1px solid #333;
+    padding: 8px;
+}
+
+.status-table th {
+    background-color: #1e1e1e;
+    color: #8ab4f8;
+}
+
+.status-table td form {
+    display: inline;
+    margin-right: 5px;
+}
 

--- a/views/squad.php
+++ b/views/squad.php
@@ -14,7 +14,7 @@
         <h2>Pautas</h2>
         <table class="pauta-table">
             <thead>
-                <tr><th>Nome</th><th>Criado em</th><th>Atualizado em</th></tr>
+                <tr><th>Nome</th><th>Criado em</th><th>Atualizado em</th><th>Ação</th></tr>
             </thead>
             <tbody>
             <?php foreach ($pautas as $p): ?>
@@ -22,6 +22,13 @@
                     <td><a href="?squad=<?= urlencode($currentSquad['slug']) ?>&pauta=<?= urlencode($p['file']) ?>"><?= htmlspecialchars($p['name']) ?></a></td>
                     <td><?= htmlspecialchars($p['created_at']) ?></td>
                     <td><?= htmlspecialchars($p['updated_at']) ?></td>
+                    <td>
+                        <form method="post" onsubmit="return confirm('Remover pauta?');">
+                            <input type="hidden" name="action" value="remove_pauta">
+                            <input type="hidden" name="pauta_file" value="<?= htmlspecialchars($p['file']) ?>">
+                            <button type="submit">Remover</button>
+                        </form>
+                    </td>
                 </tr>
             <?php endforeach; ?>
             </tbody>

--- a/views/statuses.php
+++ b/views/statuses.php
@@ -11,31 +11,40 @@
     <div class="content">
         <div class="navbar"><a href="index.php">Home</a> / Configurações / Status de comentários</div>
         <h1>Status de Comentários</h1>
-        <ul class="status-list">
+        <table class="status-table">
+            <thead>
+                <tr><th>Nome</th><th>Cor</th><th>Ação</th></tr>
+            </thead>
+            <tbody>
             <?php foreach ($statuses as $st): ?>
-                <li>
-                    <span style="color: <?= htmlspecialchars($st['color']) ?>; font-weight:bold;">
-                        <?= htmlspecialchars($st['name']) ?>
-                    </span>
-                    <form method="post" style="display:inline;">
-                        <input type="hidden" name="action" value="remove_status">
-                        <input type="hidden" name="status" value="<?= htmlspecialchars($st['name']) ?>">
-                        <button type="submit">Remover</button>
-                    </form>
-                    <form method="post" style="display:inline; margin-left:5px;">
-                        <input type="hidden" name="action" value="update_status">
-                        <input type="hidden" name="status" value="<?= htmlspecialchars($st['name']) ?>">
-                        <input type="color" name="color" value="<?= htmlspecialchars($st['color']) ?>" onchange="this.form.submit()">
-                    </form>
-                </li>
+                <tr>
+                    <td><?= htmlspecialchars($st['name']) ?></td>
+                    <td>
+                        <form method="post">
+                            <input type="hidden" name="action" value="update_status">
+                            <input type="hidden" name="status" value="<?= htmlspecialchars($st['name']) ?>">
+                            <input type="color" name="color" value="<?= htmlspecialchars($st['color']) ?>" onchange="this.form.submit()">
+                        </form>
+                    </td>
+                    <td>
+                        <form method="post">
+                            <input type="hidden" name="action" value="remove_status">
+                            <input type="hidden" name="status" value="<?= htmlspecialchars($st['name']) ?>">
+                            <button type="submit">Remover</button>
+                        </form>
+                    </td>
+                </tr>
             <?php endforeach; ?>
-        </ul>
-        <form method="post" class="add-status-form">
-            <input type="hidden" name="action" value="add_status">
-            <input type="text" name="status" placeholder="Novo status" required>
-            <input type="color" name="color" value="#ffffff">
-            <button type="submit">Adicionar</button>
-        </form>
+            <tr>
+                <form method="post">
+                    <input type="hidden" name="action" value="add_status">
+                    <td><input type="text" name="status" placeholder="Novo status" required></td>
+                    <td><input type="color" name="color" value="#ffffff"></td>
+                    <td><button type="submit">Cadastrar</button></td>
+                </form>
+            </tr>
+            </tbody>
+        </table>
     </div>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- allow removing pautas
- redesign pauta list table with nicer colors
- show comment statuses in a table format
- mention pauta removal in README

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ea03b9d8832bb3f8ce825a841706