### PR TITLE
Add pauta statuses and minimal UI tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ As pautas são editadas com o [Quill](https://quilljs.com/), um editor rich text
 Todos os usuários são armazenados em arquivos JSON em `data/users/`. A pasta já existe no repositório, mas os arquivos de dados são ignorados pelo git.
 
 O sistema também permite adicionar comentários em cada pauta. Os comentários possuem um status que pode ser configurado em "Configurações > Status de comentários". Cada status possui uma cor RGB para facilitar a visualização. Por padrão já existem três status: Aberto, Em Andamento e Resolvido. Nos comentários é exibida a data e hora de criação junto do status colorido.
+
+As pautas também contam com um status próprio configurável em "Configurações > Status de pautas". As opções iniciais são as mesmas: Aberto, Em Andamento e Resolvido. Pautas existentes sem status são tratadas como "Aberto" e novas pautas já iniciam com esse valor.

--- a/controllers/PautaStatusController.php
+++ b/controllers/PautaStatusController.php
@@ -1,0 +1,21 @@
+<?php
+require_once __DIR__ . '/../models/PautaStatus.php';
+
+class PautaStatusController {
+    public function getStatuses(): array {
+        return PautaStatus::getAll();
+    }
+
+    public function addStatus(string $status, string $color): void {
+        PautaStatus::add($status, $color);
+    }
+
+    public function updateStatus(string $status, string $color): void {
+        PautaStatus::updateColor($status, $color);
+    }
+
+    public function removeStatus(string $status): void {
+        PautaStatus::remove($status);
+    }
+}
+?>

--- a/controllers/SquadController.php
+++ b/controllers/SquadController.php
@@ -35,6 +35,10 @@ class SquadController {
         Pauta::updateCommentStatus($slug, $file, $index, $status);
     }
 
+    public function updatePautaStatus(string $slug, string $file, string $status): void {
+        Pauta::updateStatus($slug, $file, $status);
+    }
+
     public function removePauta(string $slug, string $file): void {
         Pauta::remove($slug, $file);
     }

--- a/index.php
+++ b/index.php
@@ -5,11 +5,15 @@ require_once __DIR__ . '/models/User.php';
 require_once __DIR__ . '/controllers/SquadController.php';
 require_once __DIR__ . '/controllers/CommentStatusController.php';
 require_once __DIR__ . '/models/CommentStatus.php';
+require_once __DIR__ . '/controllers/PautaStatusController.php';
+require_once __DIR__ . '/models/PautaStatus.php';
 
 $controller = new UserController();
 $squadController = new SquadController();
 $statusController = new CommentStatusController();
+$pautaStatusController = new PautaStatusController();
 $statuses = CommentStatus::getAll();
+$pautaStatuses = PautaStatus::getAll();
 $message = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -31,6 +35,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             header('Location: ?squad=' . urlencode($_GET['squad'] ?? ''));
             exit;
         }
+    } elseif (isset($_POST['action']) && $_POST['action'] === 'update_pauta_status' && isset($_SESSION['user'])) {
+        $squadController->updatePautaStatus(
+            $_GET['squad'] ?? '',
+            $_GET['pauta'] ?? '',
+            $_POST['new_status'] ?? ''
+        );
+        $pauta = $squadController->getPauta($_GET['squad'], $_GET['pauta']);
     } elseif (isset($_POST['action']) && $_POST['action'] === 'add_status' && isset($_SESSION['user'])) {
         $statusController->addStatus($_POST['status'] ?? '', $_POST['color'] ?? '#ffffff');
         $statuses = $statusController->getStatuses();
@@ -40,6 +51,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif (isset($_POST['action']) && $_POST['action'] === 'remove_status' && isset($_SESSION['user'])) {
         $statusController->removeStatus($_POST['status'] ?? '');
         $statuses = $statusController->getStatuses();
+    } elseif (isset($_POST['action']) && $_POST['action'] === 'add_pauta_status' && isset($_SESSION['user'])) {
+        $pautaStatusController->addStatus($_POST['status'] ?? '', $_POST['color'] ?? '#ffffff');
+        $pautaStatuses = $pautaStatusController->getStatuses();
+    } elseif (isset($_POST['action']) && $_POST['action'] === 'update_pauta_status_cfg' && isset($_SESSION['user'])) {
+        $pautaStatusController->updateStatus($_POST['status'] ?? '', $_POST['color'] ?? '#ffffff');
+        $pautaStatuses = $pautaStatusController->getStatuses();
+    } elseif (isset($_POST['action']) && $_POST['action'] === 'remove_pauta_status' && isset($_SESSION['user'])) {
+        $pautaStatusController->removeStatus($_POST['status'] ?? '');
+        $pautaStatuses = $pautaStatusController->getStatuses();
     } elseif (isset($_POST['action']) && $_POST['action'] === 'add_comment' && isset($_SESSION['user'])) {
         $squadController->addComment(
             $_GET['squad'] ?? '',
@@ -84,9 +104,16 @@ if (isset($_SESSION['user'])) {
     foreach ($statuses as $s) {
         $statusMap[$s['name']] = $s['color'];
     }
+    $pautaStatusMap = [];
+    foreach ($pautaStatuses as $p) {
+        $pautaStatusMap[$p['name']] = $p['color'];
+    }
     if (isset($_GET['config']) && $_GET['config'] === 'statuses') {
         $statuses = $statusController->getStatuses();
         include __DIR__ . '/views/statuses.php';
+    } elseif (isset($_GET['config']) && $_GET['config'] === 'pauta_statuses') {
+        $pautaStatuses = $pautaStatusController->getStatuses();
+        include __DIR__ . '/views/pauta_statuses.php';
     } elseif (isset($_GET['pauta']) && isset($_GET['squad'])) {
         $pauta = $squadController->getPauta($_GET['squad'], $_GET['pauta']);
         $currentSquad = Squad::getBySlug($_GET['squad']);

--- a/models/Pauta.php
+++ b/models/Pauta.php
@@ -1,6 +1,7 @@
 <?php
 class Pauta {
     private const BASE_DIR = __DIR__ . '/../data/squads';
+    private const DEFAULT_STATUS = 'Aberto';
 
     private static function slugify(string $name): string {
         $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $name));
@@ -18,6 +19,7 @@ class Pauta {
         $data = [
             'name' => $name,
             'content' => $content,
+            'status' => self::DEFAULT_STATUS,
             'created_at' => $date,
             'updated_at' => $date
         ];
@@ -38,6 +40,9 @@ class Pauta {
                 continue;
             }
             $data['file'] = basename($path);
+            if (!isset($data['status'])) {
+                $data['status'] = self::DEFAULT_STATUS;
+            }
             $pautas[] = $data;
         }
         return $pautas;
@@ -49,6 +54,9 @@ class Pauta {
             return null;
         }
         $data = json_decode(file_get_contents($path), true);
+        if ($data && !isset($data['status'])) {
+            $data['status'] = self::DEFAULT_STATUS;
+        }
         return $data ?: null;
     }
 
@@ -101,6 +109,16 @@ class Pauta {
             $data['comments'][$index]['status'] = $status;
             file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
         }
+    }
+
+    public static function updateStatus(string $squadSlug, string $file, string $status): void {
+        $path = self::BASE_DIR . "/$squadSlug/$file";
+        if (!file_exists($path)) {
+            return;
+        }
+        $data = json_decode(file_get_contents($path), true) ?: [];
+        $data['status'] = $status;
+        file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT));
     }
 
     public static function remove(string $squadSlug, string $file): void {

--- a/models/PautaStatus.php
+++ b/models/PautaStatus.php
@@ -1,0 +1,61 @@
+<?php
+class PautaStatus {
+    private const FILE = __DIR__ . '/../data/pauta_statuses.json';
+
+    public static function ensure(): void {
+        if (!file_exists(self::FILE)) {
+            $default = [
+                ['name' => 'Aberto', 'color' => '#ff0000'],
+                ['name' => 'Em Andamento', 'color' => '#ffff00'],
+                ['name' => 'Resolvido', 'color' => '#00ff00']
+            ];
+            if (!is_dir(dirname(self::FILE))) {
+                mkdir(dirname(self::FILE), 0777, true);
+            }
+            file_put_contents(self::FILE, json_encode($default, JSON_PRETTY_PRINT));
+        }
+    }
+
+    public static function getAll(): array {
+        self::ensure();
+        $data = json_decode(file_get_contents(self::FILE), true);
+        if (is_array($data) && isset($data[0]) && is_string($data[0])) {
+            $data = array_map(fn($s) => ['name' => $s, 'color' => '#ffffff'], $data);
+            file_put_contents(self::FILE, json_encode($data, JSON_PRETTY_PRINT));
+        }
+        return is_array($data) ? $data : [];
+    }
+
+    public static function add(string $status, string $color): void {
+        $status = trim($status);
+        $color = trim($color);
+        if ($status === '' || $color === '') {
+            return;
+        }
+        $statuses = self::getAll();
+        foreach ($statuses as $st) {
+            if ($st['name'] === $status) {
+                return;
+            }
+        }
+        $statuses[] = ['name' => $status, 'color' => $color];
+        file_put_contents(self::FILE, json_encode($statuses, JSON_PRETTY_PRINT));
+    }
+
+    public static function updateColor(string $status, string $color): void {
+        $statuses = self::getAll();
+        foreach ($statuses as &$st) {
+            if ($st['name'] === $status) {
+                $st['color'] = $color;
+            }
+        }
+        file_put_contents(self::FILE, json_encode($statuses, JSON_PRETTY_PRINT));
+    }
+
+    public static function remove(string $status): void {
+        $statuses = self::getAll();
+        $statuses = array_values(array_filter($statuses, fn($s) => $s['name'] !== $status));
+        file_put_contents(self::FILE, json_encode($statuses, JSON_PRETTY_PRINT));
+    }
+}
+?>

--- a/public/style.css
+++ b/public/style.css
@@ -13,12 +13,12 @@ body {
 }
 input, button {
     width: 100%;
-    padding: 10px;
-    margin: 5px 0;
-    background-color: #333;
+    padding: 8px;
+    margin: 4px 0;
+    background-color: #1e1e1e;
     color: #fff;
-    border: none;
-    border-radius: 4px;
+    border: 1px solid #444;
+    border-radius: 2px;
 }
 a, a:visited {
     color: #8ab4f8;
@@ -27,18 +27,18 @@ a, a:visited {
     display: flex;
 }
 .menu-left {
-    width: 200px;
+    width: 180px;
     background-color: #1e1e1e;
-    padding: 20px;
+    padding: 15px;
     height: 100vh;
 }
 .menu-left a {
     display: block;
-    padding: 10px 0;
+    padding: 8px 0;
     text-decoration: none;
 }
 .menu-left a:hover {
-    background-color: #333;
+    background-color: #222;
 }
 .content {
     flex: 1;
@@ -102,8 +102,8 @@ a, a:visited {
 
 .pauta-table th,
 .pauta-table td {
-    border: 1px solid #333;
-    padding: 8px;
+    border: 1px solid #444;
+    padding: 6px;
 }
 
 .pauta-table th {
@@ -116,7 +116,7 @@ a, a:visited {
 }
 
 .pauta-table tr:hover {
-    background-color: #2a2a2a;
+    background-color: #262626;
 }
 
 .add-pauta-form {
@@ -134,7 +134,8 @@ a, a:visited {
 }
 
 .button-row button {
-    width: 100%;
+    width: auto;
+    padding: 8px 12px;
 }
 
 .comment-list { list-style: none; padding: 0; }
@@ -149,8 +150,8 @@ a, a:visited {
 
 .status-table th,
 .status-table td {
-    border: 1px solid #333;
-    padding: 8px;
+    border: 1px solid #444;
+    padding: 6px;
 }
 
 .status-table th {

--- a/views/partials/sidebar.php
+++ b/views/partials/sidebar.php
@@ -22,6 +22,7 @@
         <span>Configurações</span>
         <div class="submenu">
             <a href="?config=statuses">Status de comentários</a>
+            <a href="?config=pauta_statuses">Status de pautas</a>
         </div>
     </div>
     <a href="?logout=1">Sair</a>

--- a/views/pauta.php
+++ b/views/pauta.php
@@ -17,6 +17,17 @@
             / <?= htmlspecialchars($pauta['name']) ?>
         </div>
         <h1><?= htmlspecialchars($pauta['name']) ?></h1>
+            <div style="margin-bottom:10px;">
+                <form method="post" id="pauta-status-form">
+                    <input type="hidden" name="action" value="update_pauta_status">
+                    <select name="new_status" onchange="document.getElementById('pauta-status-form').submit()">
+                        <?php foreach ($pautaStatuses as $st): ?>
+                            <option value="<?= htmlspecialchars($st['name']) ?>" style="color: <?= htmlspecialchars($st['color']) ?>;" <?= ($pauta['status'] ?? 'Aberto') === $st['name'] ? 'selected' : '' ?>><?= htmlspecialchars($st['name']) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </form>
+            </div>
+
         <form method="post" enctype="multipart/form-data" id="pauta-form">
             <input type="hidden" name="action" value="save_pauta">
             <input type="hidden" name="content" id="content-input">

--- a/views/pauta_statuses.php
+++ b/views/pauta_statuses.php
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>SafeHm - Status de Pautas</title>
+    <link rel="stylesheet" href="public/style.css">
+</head>
+<body>
+<div class="menu">
+    <?php include __DIR__ . '/partials/sidebar.php'; ?>
+    <div class="content">
+        <div class="navbar"><a href="index.php">Home</a> / Configurações / Status de pautas</div>
+        <h1>Status de Pautas</h1>
+        <table class="status-table">
+            <thead>
+                <tr><th>Nome</th><th>Cor</th><th>Ação</th></tr>
+            </thead>
+            <tbody>
+            <?php foreach ($pautaStatuses as $st): ?>
+                <tr>
+                    <td><?= htmlspecialchars($st['name']) ?></td>
+                    <td>
+                        <form method="post">
+                            <input type="hidden" name="action" value="update_pauta_status_cfg">
+                            <input type="hidden" name="status" value="<?= htmlspecialchars($st['name']) ?>">
+                            <input type="color" name="color" value="<?= htmlspecialchars($st['color']) ?>" onchange="this.form.submit()">
+                        </form>
+                    </td>
+                    <td>
+                        <form method="post">
+                            <input type="hidden" name="action" value="remove_pauta_status">
+                            <input type="hidden" name="status" value="<?= htmlspecialchars($st['name']) ?>">
+                            <button type="submit">Remover</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+            <tr>
+                <form method="post">
+                    <input type="hidden" name="action" value="add_pauta_status">
+                    <td><input type="text" name="status" placeholder="Novo status" required></td>
+                    <td><input type="color" name="color" value="#ffffff"></td>
+                    <td><button type="submit">Cadastrar</button></td>
+                </form>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+</body>
+</html>

--- a/views/squad.php
+++ b/views/squad.php
@@ -14,12 +14,15 @@
         <h2>Pautas</h2>
         <table class="pauta-table">
             <thead>
-                <tr><th>Nome</th><th>Criado em</th><th>Atualizado em</th><th>Ação</th></tr>
+                <tr><th>Nome</th><th>Status</th><th>Criado em</th><th>Atualizado em</th><th>Ação</th></tr>
             </thead>
             <tbody>
             <?php foreach ($pautas as $p): ?>
                 <tr>
                     <td><a href="?squad=<?= urlencode($currentSquad['slug']) ?>&pauta=<?= urlencode($p['file']) ?>"><?= htmlspecialchars($p['name']) ?></a></td>
+                    <td style="color: <?= htmlspecialchars($pautaStatusMap[$p['status']] ?? '#fff') ?>; font-weight:bold;">
+                        <?= htmlspecialchars($p['status']) ?>
+                    </td>
                     <td><?= htmlspecialchars($p['created_at']) ?></td>
                     <td><?= htmlspecialchars($p['updated_at']) ?></td>
                     <td>


### PR DESCRIPTION
## Summary
- tweak CSS for minimalistic look
- manage status of pautas with configuration screen
- show pauta status in lists and allow changing
- support updating pauta status in controller
- document new feature in README

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864568d2c88832b9c144389cf63c681